### PR TITLE
fix: Add IBC types in registry to show governance votes [DEV-1349]

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "axios": "^0.21.1",
         "bootstrap": "^5.1.2",
         "clipboard": "^2.0.6",
-        "cosmjs-types": "^0.4.0",
+        "cosmjs-types": "^0.5.0",
         "crypto-js": "^4.1.1",
         "cryptojs": "^2.5.3",
         "dayjs": "^1.10.4",

--- a/src/network/modules/registry.ts
+++ b/src/network/modules/registry.ts
@@ -59,6 +59,31 @@ import { MsgCreateVestingAccount } from '@lum-network/sdk-javascript/build/codec
 import { MsgCreateDid } from 'network/cheqd/v1/tx';
 import { CheqDenom } from 'network/constants';
 import { TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
+import {
+	MsgAcknowledgement,
+	MsgChannelCloseConfirm,
+	MsgChannelCloseInit,
+	MsgChannelOpenAck,
+	MsgChannelOpenConfirm,
+	MsgChannelOpenInit,
+	MsgChannelOpenTry,
+	MsgRecvPacket,
+	MsgTimeout,
+	MsgTimeoutOnClose,
+} from 'cosmjs-types/ibc/core/channel/v1/tx';
+import {
+	MsgCreateClient,
+	MsgSubmitMisbehaviour,
+	MsgUpdateClient,
+	MsgUpgradeClient,
+} from 'cosmjs-types/ibc/core/client/v1/tx';
+import {
+	MsgConnectionOpenAck,
+	MsgConnectionOpenConfirm,
+	MsgConnectionOpenInit,
+	MsgConnectionOpenTry,
+} from 'cosmjs-types/ibc/core/connection/v1/tx';
+import { ClientUpdateProposal } from 'cosmjs-types/ibc/core/client/v1/client';
 
 const registryTypes: Iterable<[string, GeneratedType]> = [
 	['/cosmos.tx.v1beta1.TxBody', TxBody],
@@ -104,6 +129,25 @@ const registryTypes: Iterable<[string, GeneratedType]> = [
 	['/cosmos.vesting.v1beta1.PeriodicVestingAccount', PeriodicVestingAccount],
 	['/cosmos.vesting.v1beta1.MsgCreateVestingAccount', MsgCreateVestingAccount],
 	['/cheqdid.cheqdnode.cheqd.v1.MsgCreateDid', MsgCreateDid],
+	['/ibc.core.client.v1.ClientUpdateProposal', ClientUpdateProposal],
+	['/ibc.core.channel.v1.MsgChannelOpenInit', MsgChannelOpenInit],
+	['/ibc.core.channel.v1.MsgChannelOpenTry', MsgChannelOpenTry],
+	['/ibc.core.channel.v1.MsgChannelOpenAck', MsgChannelOpenAck],
+	['/ibc.core.channel.v1.MsgChannelOpenConfirm', MsgChannelOpenConfirm],
+	['/ibc.core.channel.v1.MsgChannelCloseInit', MsgChannelCloseInit],
+	['/ibc.core.channel.v1.MsgChannelCloseConfirm', MsgChannelCloseConfirm],
+	['/ibc.core.channel.v1.MsgRecvPacket', MsgRecvPacket],
+	['/ibc.core.channel.v1.MsgTimeout', MsgTimeout],
+	['/ibc.core.channel.v1.MsgTimeoutOnClose', MsgTimeoutOnClose],
+	['/ibc.core.channel.v1.MsgAcknowledgement', MsgAcknowledgement],
+	['/ibc.core.client.v1.MsgCreateClient', MsgCreateClient],
+	['/ibc.core.client.v1.MsgUpdateClient', MsgUpdateClient],
+	['/ibc.core.client.v1.MsgUpgradeClient', MsgUpgradeClient],
+	['/ibc.core.client.v1.MsgSubmitMisbehaviour', MsgSubmitMisbehaviour],
+	['/ibc.core.connection.v1.MsgConnectionOpenInit', MsgConnectionOpenInit],
+	['/ibc.core.connection.v1.MsgConnectionOpenTry', MsgConnectionOpenTry],
+	['/ibc.core.connection.v1.MsgConnectionOpenAck', MsgConnectionOpenAck],
+	['/ibc.core.connection.v1.MsgConnectionOpenConfirm', MsgConnectionOpenConfirm],
 ];
 
 class ExtendedRegistry extends Registry {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4582,6 +4582,14 @@ cosmjs-types@^0.4.0:
     long "^4.0.0"
     protobufjs "~6.11.2"
 
+cosmjs-types@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cosmjs-types/-/cosmjs-types-0.5.0.tgz#2497a2c5ddf62a8e8dea03e0725b8cd763d4ab4f"
+  integrity sha512-Qy2yxDp5HasBUnBV5OL9EOuTJw94LAbCWfiRb5QcW1sqh93KSSY5PpNMB3rTsxwuPcf/k3CNRY02DeQMjrsJuA==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "~6.11.2"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"


### PR DESCRIPTION
We missed ibc types in our Protobuf Registry because of which,
governance tab was not showing any proposals (old or new) and was
failing to load any information. The main issue was with
`/ibc.core.client.v1.ClientUpdateProposal` type and is now being
registered with other common IBC data types.

Also bumps `cosmjs-types` to `v0.5.0`

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>