### PR TITLE
fix: Button text on Identity Page in Light Mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 build: submodule yarn-install
 	yarn build
 
+start: submodule yarn-install
+	yarn start
+
 submodule:
 	git submodule update --init --remote --merge
 

--- a/src/components/Buttons/Buttons.scss
+++ b/src/components/Buttons/Buttons.scss
@@ -47,7 +47,7 @@ button:focus {
     &.outline {
         background-color: transparent;
         border: 1px solid $color-primary;
-        color: white;
+        color: $color-primary;
     }
 }
 

--- a/src/screens/Identity/Identity.tsx
+++ b/src/screens/Identity/Identity.tsx
@@ -326,7 +326,10 @@ const Identity = (): JSX.Element => {
 											}
 											)}
 										</div>
-										<CustomButton className="mt-3 btn-sm btn-outline-secondary outline border-1" onClick={handleConnectSocialAccount}>
+										<CustomButton
+											className="px-5 btn-sm btn-outline-secondary outline border-1"
+											onClick={handleConnectSocialAccount}
+										>
 											{t('identity.get.connections.connect')}
 										</CustomButton>
 									</div>

--- a/src/screens/Identity/components/VerifyBadge.tsx
+++ b/src/screens/Identity/components/VerifyBadge.tsx
@@ -13,7 +13,7 @@ const CredentialVerificatinBadge: React.FC<Props> = ({ verified }): JSX.Element 
 	const { t } = useTranslation();
 	if (verified === CredentialVerificationState.Success) {
 		return (
-			<div className="">
+			<div>
 				<div className={`app-badge success`}>
 					<p className="text success">
 						<img alt="checkmark" src={Assets.images.checkmarkIcon} />{' '}
@@ -25,7 +25,7 @@ const CredentialVerificatinBadge: React.FC<Props> = ({ verified }): JSX.Element 
 	}
 
 	return (
-		<div className="">
+		<div>
 			<div className='app-badge warning'>
 				<p className="text warning">
 					<img alt="checkmark" src={Assets.images.crossIcon} />{' '}


### PR DESCRIPTION
The `Connect Social Account` and `Verify` buttons were showing as white pills without any text on it in Light Theme.
This PR fixes that by using the proper SCSS variable for switching the
colors inside Dark or Light Themes

### Before the Issue was fixed:
![image](https://user-images.githubusercontent.com/10788442/184311070-83e5ff8b-a084-426f-b07b-0c2c442b5671.png)

### Now:
**Dark Mode**
![image](https://user-images.githubusercontent.com/10788442/184311246-42f2c27d-d11f-4f93-bf01-79ef0e795558.png)

**Light Mode**
![image](https://user-images.githubusercontent.com/10788442/184311315-cde09460-651c-4f88-967a-eb8b6ce25e6e.png)
