### PR TITLE
fix: Retry button in WrongPassphrase modal

### DIFF
--- a/src/screens/Identity/Identity.tsx
+++ b/src/screens/Identity/Identity.tsx
@@ -436,7 +436,7 @@ const Identity = (): JSX.Element => {
 					<h1 className="logout-modal-title">{t('identity.wallet.error.invalidPassphrase')}</h1>
 					<div className="d-flex flex-column flex-sm-row  justify-content-around mt-4">
 						<CustomButton
-							className="logout-modal-btn me-sm-3 mb-4 mb-sm-0"
+							className="logout-modal-cancel-btn me-sm-3 mb-4 mb-sm-0"
 							data-bs-dismiss="modal"
 							onClick={() => handlePassphrase(authToken!)}
 						>


### PR DESCRIPTION
## Bug - In dark mode, the `Retry` button looks like a white blob
![SCR-20220830-c7z](https://user-images.githubusercontent.com/10788442/188561477-aec018cc-a19e-4395-9a08-255e6565f6c2.png)

## Fix
![SCR-20220830-ceu](https://user-images.githubusercontent.com/10788442/188561491-d43262d2-2394-4ff6-aefe-6bfab0c8b0d2.png)
