### PR TITLE
feat: Register IBC MsgTransfer type in protobuf registry

### DIFF
--- a/src/network/modules/registry.ts
+++ b/src/network/modules/registry.ts
@@ -39,6 +39,7 @@ import {
 	DelayedVestingAccount,
 	PeriodicVestingAccount
 } from 'cosmjs-types/cosmos/vesting/v1beta1/vesting';
+import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx';
 import {
 	MsgAcknowledgement,
 	MsgChannelCloseConfirm,
@@ -130,6 +131,7 @@ const registryTypes: Iterable<[string, GeneratedType]> = [
 	['/ibc.core.connection.v1.MsgConnectionOpenTry', MsgConnectionOpenTry],
 	['/ibc.core.connection.v1.MsgConnectionOpenAck', MsgConnectionOpenAck],
 	['/ibc.core.connection.v1.MsgConnectionOpenConfirm', MsgConnectionOpenConfirm],
+	['/ibc.applications.transfer.v1.MsgTransfer', MsgTransfer],
 ];
 
 class ExtendedRegistry extends Registry {


### PR DESCRIPTION
Wallet's transaction table would crash if you've done an IBC transaction in the past. This was because we didn't register the `IBC MsgTransfer` type in our Protobuf Registry.

This PR adds that message type in the registry and fixes this issue