### PR TITLE
fix: Background and text color overlap on creds

### DIFF
--- a/src/screens/Identity/Identity.tsx
+++ b/src/screens/Identity/Identity.tsx
@@ -514,7 +514,7 @@ const Identity = (): JSX.Element => {
 								<div className="d-flex flex-row align-items-left tabs my-3">
 									<a
 										href="#formatted"
-										className="app-btn app-btn-plain bg-transparent text-btn p-0 me-4 h-auto active"
+										className="app-btn-plain bg-transparent text-btn p-0 me-4 h-auto active"
 										id="tab-formatted"
 										onClick={() => changeActiveTab('tab-formatted')}
 									>
@@ -523,7 +523,7 @@ const Identity = (): JSX.Element => {
 									</a>
 									<a
 										href="#json"
-										className="app-btn  app-btn-plain bg-transparent text-btn p-0 me-4 h-auto"
+										className="app-btn-plain bg-transparent text-btn p-0 me-4 h-auto"
 										id="tab-json"
 										onClick={() => changeActiveTab('tab-json')}
 									>
@@ -532,7 +532,7 @@ const Identity = (): JSX.Element => {
 									</a>
 									<a
 										href="#qr-code"
-										className="app-btn  app-btn-plain bg-transparent text-btn p-0 me-4 h-auto"
+										className="app-btn-plain bg-transparent text-btn p-0 me-4 h-auto"
 										id="tab-qr"
 										onClick={() => changeActiveTab('tab-qr')}
 									>


### PR DESCRIPTION
The tab buttons (formatted, json, QRCode) in the credential details view were not visible since the background and button colours overlapped. This PR fixes that


### Fix 

<img width="755" alt="image" src="https://user-images.githubusercontent.com/10788442/199662304-d5517fc6-8e71-4734-be2f-49da249e3621.png">
