### PR TITLE
feat: Add support for multiple Auth0 providers [DEV-1920]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cheqd/wallet",
-    "version": "1.1.1",
+    "version": "1.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@cheqd/wallet",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@auth0/auth0-spa-js": "^1.22.5",

--- a/src/apis/issuer.ts
+++ b/src/apis/issuer.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
 import { Credential } from '../models';
 
-export const getCredential = async (subjectId: string, claim: string): Promise<Credential> => {
+export const getCredential = async (subjectId: string, claim: string, provider: string): Promise<Credential> => {
 	const resp = await axios.post<Credential>(import.meta.env.VITE_ISSUER_ENDPOINT + '/api/credentials/issue', {
 		subjectId,
 		claim,
-		provider: "twitter" // TODO: Get rid of this
+		provider
 	});
 	return resp.data;
 };

--- a/src/screens/Identity/Identity.tsx
+++ b/src/screens/Identity/Identity.tsx
@@ -65,6 +65,10 @@ const Identity = (): JSX.Element => {
 
 	// Methods
 	const handleConnectSocialAccount = async () => {
+		if (claims.length > 0) {
+			showErrorToast('Social profile is already connected. Try removing the existing profile first')
+			return
+		}
 		try {
 			const auth0 = await createAuth0Client({
 				domain: import.meta.env.VITE_AUTH0_DOMAIN,
@@ -351,12 +355,15 @@ const Identity = (): JSX.Element => {
 											}
 											)}
 										</div>
-										<CustomButton
-											className="px-5 btn-sm btn-outline-secondary outline border-1"
-											onClick={handleConnectSocialAccount}
-										>
-											{t('identity.get.connections.connect')}
-										</CustomButton>
+										{claims.length === 0 ?
+											<CustomButton
+												className="px-5 btn-sm btn-outline-secondary outline border-1"
+												onClick={handleConnectSocialAccount}
+											>
+												{t('identity.get.connections.connect')}
+											</CustomButton>
+											: null
+										}
 									</div>
 									<div>
 										<CustomButton className="px-5" onClick={handleGetCredential}>

--- a/src/screens/Identity/Identity.tsx
+++ b/src/screens/Identity/Identity.tsx
@@ -31,6 +31,7 @@ const Identity = (): JSX.Element => {
 	const [passphraseInput, setPassphraseInput] = useState('');
 	const [activeVC, setActiveVC] = useState<VerifiableCredential | null>(null);
 	const credentialDetailedRef = useRef<HTMLDivElement>(null);
+	const [selectedAuth0Provider, setSelectedAuth0Provider] = useState(0);
 	// Redux hooks
 	const { wallet, identityWallet, authToken, passphrase, claims } = useSelector((state: RootState) => ({
 		wallet: state.wallet.currentWallet,
@@ -132,12 +133,12 @@ const Identity = (): JSX.Element => {
 			}
 
 			// Get credential
-			if (claims.length !== 1) {
+			if (claims.length == 0) {
 				showInfoToast(t("identity.get.message.connectionNeeded"));
 				return;
 			}
 
-			const cred = await getCredential(getSubjectId(wallet), claims[0].accessToken);
+			const cred = await getCredential(getSubjectId(wallet), claims[0].accessToken, claims[0].service);
 
 			const newWallet = update(identityWallet, { credentials: { $push: [cred] } });
 
@@ -339,7 +340,7 @@ const Identity = (): JSX.Element => {
 									</div>
 									<div className="px-3">
 										<h3>{t('identity.get.connections.title')}</h3>
-										<div className="mt-2">
+										<div className="mt-2 mb-2">
 											{claims.map((claim) => {
 												return (
 													<div key={claim.profileName} className="claim d-flex flex-row">


### PR DESCRIPTION
We now enable the the user to select a social provider at a time. You can login with Twitter and get a credential. Then remove Twitter connection and add another one (say GitHub) and the new credentials would use GitHub as the provider